### PR TITLE
Remove Windows-specifics from the Linux build file

### DIFF
--- a/build_files/linux.xml
+++ b/build_files/linux.xml
@@ -24,7 +24,9 @@
             <file name="${glfw_folder}/src/input.c" />
             <file name="${glfw_folder}/src/monitor.c" />
             <file name="${glfw_folder}/src/context.c" />
+            <!-- Can't use Windows extensions
             <file name="${glfw_folder}/src/wgl_context.c" />
+            -->
             <file name="${glfw_folder}/src/egl_context.c" />
             <file name="${glfw_folder}/src/osmesa_context.c" />
             <file name="${glfw_folder}/src/vulkan.c" />
@@ -44,9 +46,7 @@
         
         <!-- LINUX SPECIFICS -->
         <target id="haxe" tool="linker" if="linux">
-            <lib name="Winmm.lib" />
-            <lib name="Gdi32.lib" />
-            <lib name="Shell32.lib" />
+            
         </target>
     </section>    
 </xml>


### PR DESCRIPTION
This should fix the Linux build. Tested on Arch Linux version 5.12.14-arch1-1.